### PR TITLE
Add cancel-pot

### DIFF
--- a/simnet/contracts/stackspot-distribute.clar
+++ b/simnet/contracts/stackspot-distribute.clar
@@ -149,42 +149,30 @@
         (asserts! (is-eq contract-caller .stackspots) ERR_UNAUTHORIZED)
 
         ;; Dispatch platform royalty reward
-        (try!
-            (if (> platform-royalty-reward u0)
-                (dispatch-rewards-with-sbtc platform-royalty-reward pot-treasury platform-royalty-address (to-consensus-buff? "platform royalty reward"))
-                (ok false)
-            )            
+
+        (and (> platform-royalty-reward u0)
+            (try! (dispatch-rewards-with-sbtc platform-royalty-reward pot-treasury platform-royalty-address (to-consensus-buff? "platform royalty reward")))
         )
 
         ;; Dispatch pot fee reward
-        (try!
-            (if (> pot-fee u0)
-                (dispatch-rewards-with-sbtc pot-fee pot-treasury pot-owner-address (to-consensus-buff? "pot fee reward"))
-                (ok false)
-            )
+
+        (and (> pot-fee u0)
+            (try! (dispatch-rewards-with-sbtc pot-fee pot-treasury pot-owner-address (to-consensus-buff? "pot fee reward")))
         )
         ;; Dispatch pot starter reward
-        (try!
-            (if (> pot-starter-reward u0)
-                (dispatch-rewards-with-sbtc pot-starter-reward pot-treasury pot-starter-address (to-consensus-buff? "pot starter reward"))
-                (ok false)
-            )            
+
+        (and (> pot-starter-reward u0)
+            (try! (dispatch-rewards-with-sbtc pot-starter-reward pot-treasury pot-starter-address (to-consensus-buff? "pot starter reward")))
         )
 
         ;; Dispatch claimer reward
-        (try!
-            (if (> claimer-reward u0)
-                (dispatch-rewards-with-sbtc claimer-reward pot-treasury claimer-address (to-consensus-buff? "claimer reward"))
-                (ok false)
-            )            
+        (and (> claimer-reward u0)
+            (try! (dispatch-rewards-with-sbtc claimer-reward pot-treasury claimer-address (to-consensus-buff? "claimer reward")))
         )
 
         ;; Dispatch winner reward
-        (try!
-            (if (> winner-reward u0)
-                (dispatch-rewards-with-sbtc winner-reward pot-treasury winner-address (to-consensus-buff? "winner reward"))
-                (ok false)
-            )            
+        (and (> winner-reward u0)
+            (try! (dispatch-rewards-with-sbtc winner-reward pot-treasury winner-address (to-consensus-buff? "winner reward")))
         )
 
         (try! (contract-call? .stackspot-winners log-winner (unwrap! (to-consensus-buff?
@@ -220,7 +208,7 @@
                 stacks-block-height: stacks-block-height,
                 burn-block-height: burn-block-height
             }
-            ) ERR_NOT_FOUND))            
+            ) ERR_NOT_FOUND))
         )
 
         ;; Print event

--- a/simnet/contracts/stackspot-distribute.clar
+++ b/simnet/contracts/stackspot-distribute.clar
@@ -35,7 +35,7 @@
     )
 )
 
-;; pot Join Stop validation
+;; pot Join End validation
 (define-read-only (validate-can-pool-pot (lock-burn-height uint))
     (let
         (

--- a/simnet/contracts/stackspot-jackpot.clar
+++ b/simnet/contracts/stackspot-jackpot.clar
@@ -296,6 +296,7 @@
       (asserts! (not (var-get locked)) ERR_POT_ALREADY_STARTED)
       (asserts! (> burn-block-height (+ (default-to burn-block-height (var-get first-user-joined)) MORE_THAN_ONE_CYCLE)) ERR_TOO_EARLY)
       (asserts! (is-eq (contract-of pot-contract) pot-treasury-address) ERR_ADMIN_ONLY)
+      (asserts! (is-eq tx-sender pot-admin) ERR_ADMIN_ONLY)
 
       ;; Returns participants principals
       (try! (as-contract (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.stackspots dispatch-principals pot-contract)))

--- a/simnet/contracts/stackspot-jackpot.clar
+++ b/simnet/contracts/stackspot-jackpot.clar
@@ -296,7 +296,6 @@
       (asserts! (not (var-get locked)) ERR_POT_ALREADY_STARTED)
       (asserts! (> burn-block-height (+ (default-to burn-block-height (var-get first-user-joined)) MORE_THAN_ONE_CYCLE)) ERR_TOO_EARLY)
       (asserts! (is-eq (contract-of pot-contract) pot-treasury-address) ERR_ADMIN_ONLY)
-      (asserts! (is-eq tx-sender pot-admin) ERR_ADMIN_ONLY)
 
       ;; Returns participants principals
       (try! (as-contract (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.stackspots dispatch-principals pot-contract)))

--- a/simnet/contracts/stackspot-jackpot.clar
+++ b/simnet/contracts/stackspot-jackpot.clar
@@ -23,14 +23,16 @@
 (define-constant ERR_DELEGATE_FAILED (err u1406))
 (define-constant ERR_DISPATCH_FAILED (err u1108))
 (define-constant ERR_POT_JOIN_FAILED (err u1408))
+(define-constant ERR_TOO_EARLY (err u1409))
+
+(define-constant JOIN_POT_MEMO (unwrap-panic (to-consensus-buff? "join pot")))
+(define-constant LEAVE_POT_MEMO (unwrap-panic (to-consensus-buff? "leave pot")))
 
 ;; Pot Starter Principal
 ;; Pot Claimer Principal
 (define-data-var pot-starter-principal (optional principal) none)
 (define-data-var pot-claimer-principal (optional principal) none)
 (define-data-var winners-values (optional {winner-id: uint, winner-address: principal}) none)
-;; Pot Rounds Counter
-(define-data-var pot-rounds uint u0)
 
 ;; Pot Participants Maps
 (define-map pot-participants-by-principal principal uint)
@@ -39,14 +41,16 @@
 ;; Locking Mechanism To Prevent Participants From Trying To Join The Pot While The Pot Is Stacked In Pool
 (define-data-var locked bool false)
 (define-data-var lock-burn-height uint u0)
+(define-data-var first-user-joined uint u0)
 
 ;; Get PoX Info and return pool config
-(define-read-only (get-pox-info)
-    (unwrap-panic (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sim-pox-4 get-pox-info))
-)
+(define-constant pox-data (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sim-pox-4 get-pox-info))
+(define-constant pox-details (unwrap! pox-data ERR_NOT_FOUND))
+(define-constant ONE_CYCLE (+ (get prepare-cycle-length pox-details) (get reward-cycle-length pox-details)) )
+
 (define-read-only (get-pool-config)
     (let (
-            (pox-details (get-pox-info))
+            
             (first (get first-burnchain-block-height pox-details))
             (cycle-len (get reward-cycle-length pox-details))
             (prepare-len (get prepare-cycle-length pox-details))
@@ -246,7 +250,7 @@
         (map-insert pot-participants-by-id index-participants {participant: participant, amount: amount})
 
         ;; Transfers User's Delegated Amount To Pot Treasury
-        (asserts! (is-ok (stx-transfer-memo? amount participant pot-treasury-address (unwrap! (to-consensus-buff? "join pot") ERR_NOT_FOUND))) ERR_POT_JOIN_FAILED)
+        (asserts! (is-ok (stx-transfer-memo? amount participant pot-treasury-address JOIN_POT_MEMO)) ERR_POT_JOIN_FAILED)
 
         ;; Updates Pot Value
         (add-pot-value amount)
@@ -268,7 +272,7 @@
 )
 
 ;; Public Function That Initiates The Payments
-(define-public (join-pot (amount uint) (participant principal))
+(define-public (join-pot (amount uint))
     (begin
 
         ;; Validate can join pot
@@ -277,39 +281,55 @@
         ;; Delegate to pot
         (asserts! (not (var-get locked)) ERR_POT_JOIN_CLOSED)
         (asserts! (> amount u0) ERR_INSUFFICIENT_AMOUNT)
-        (asserts! (is-eq tx-sender participant) ERR_PARTICIPANT_ONLY)
 
-        (try! (delegate-to-pot amount participant))
+        (try! (delegate-to-pot amount tx-sender))
 
         (ok true)
     )
 )
 
+(define-public (cancel-pot)
+    (begin 
+      (asserts! (not (var-get locked)) ERR_POT_ALREADY_STARTED)
+      (asserts! (> burn-block-height (+ (var-get first-user-joined) ONE_CYCLE)) ERR_TOO_EARLY)
+
+      ;; Returns participants principals
+      (try! (as-contract (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.stackspots dispatch-principals pot-treasury-address)))
+
+      ;; Disburse rewards
+      (try! (as-contract (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.stackspots dispatch-rewards pot-contract)))
+      (ok true)
+    )
+)
+
+(define-read-only (as-trait ()))
+
 ;; Public Function That Starts The Jackpot
 (define-public (start-stackspot-jackpot (pot-contract <stackspot-trait>))
-    (let ((pot-treasury pot-treasury-address))
+    (begin
+
+        (var-set lock-burn-height burn-block-height)
 
         ;; Validate can pool pot
-        ;; Validate pot treasury is the same as the pot contract
         (asserts! (validate-can-pool-pot) ERR_POOL_ENTRY_PASSED)
-        (asserts! (is-eq pot-treasury (contract-of pot-contract)) ERR_UNAUTHORIZED)
+        ;; Validate pot treasury is the same as the pot contract
+        (asserts! (is-eq pot-treasury-address (contract-of pot-contract)) ERR_UNAUTHORIZED)
 
         ;; Delegate treasury to pot contract
-        (try! (as-contract (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.stackspots delegate-treasury pot-contract pot-treasury)))
+        (try! (as-contract (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.stackspots delegate-treasury pot-contract pot-treasury-address)))
 
         ;; Set pot starter principal
         (var-set pot-starter-principal (some tx-sender))
 
         ;; Lock pot
         (var-set locked true)
-        (var-set lock-burn-height burn-block-height)
 
         ;; Print
         (print {
             event: "start-stackspot-jackpot",
             pot-starter-principal: tx-sender,
             pot-contract: (contract-of pot-contract),
-            pot-treasury: pot-treasury,
+            pot-treasury: pot-treasury-address,
             pot-participants: (unwrap! (get-pot-participants) ERR_NOT_FOUND),
             pot-value: (var-get total-pot-value),
             pot-locked: (var-get locked),
@@ -363,7 +383,7 @@
         (try! (as-contract (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.stackspots dispatch-principals pot-contract)))
 
         ;; Disburse rewards
-        (asserts! (is-ok (as-contract (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.stackspots dispatch-rewards pot-contract))) ERR_DISPATCH_FAILED)
+        (try! (as-contract (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.stackspots dispatch-rewards pot-contract)))
 
         ;; Print
         (print {

--- a/simnet/tests/stackspot-happy-path.test.ts
+++ b/simnet/tests/stackspot-happy-path.test.ts
@@ -61,7 +61,23 @@ describe("happy-path", () => {
     let txReceipt = simnet.callPublicFn(
       `${address1}.stackpot2`,
       "join-pot",
-      [Cl.uint(10000000), Cl.principal(address2)],
+      [Cl.uint(10000000)],
+      address2
+    );
+    expect(txReceipt.result).toBeOk(Cl.bool(true));
+
+    txReceipt = simnet.callPublicFn(
+      `${address1}.stackpot2`,
+      "leave-pot",
+      [],
+      address2
+    );
+    expect(txReceipt.result).toBeOk(Cl.bool(true));
+
+    txReceipt = simnet.callPublicFn(
+      `${address1}.stackpot2`,
+      "join-pot",
+      [Cl.uint(10000000)],
       address2
     );
     expect(txReceipt.result).toBeOk(Cl.bool(true));

--- a/simnet/tests/stackspot-happy-path.test.ts
+++ b/simnet/tests/stackspot-happy-path.test.ts
@@ -146,7 +146,7 @@ describe("happy-path", () => {
       `${address1}.stackpot2`,
       "cancel-pot",
       [Cl.principal(`${address1}.stackpot2`)],
-      address1
+      address2
     );
     expect(txReceipt.result).toBeOk(Cl.bool(true));
     expect(txReceipt.events.length).toEqual(2); // stx transfer + print event

--- a/simnet/tests/stackspot-happy-path.test.ts
+++ b/simnet/tests/stackspot-happy-path.test.ts
@@ -146,7 +146,7 @@ describe("happy-path", () => {
       `${address1}.stackpot2`,
       "cancel-pot",
       [Cl.principal(`${address1}.stackpot2`)],
-      address2
+      address1
     );
     expect(txReceipt.result).toBeOk(Cl.bool(true));
     expect(txReceipt.events.length).toEqual(2); // stx transfer + print event

--- a/simnet/tests/stackspots.test.ts
+++ b/simnet/tests/stackspots.test.ts
@@ -21,7 +21,7 @@ describe("join-pot", () => {
     let txReceipt = simnet.callPublicFn(
       `${address1}.stackpot2`,
       "join-pot",
-      [Cl.uint(10000000), Cl.principal(address2)],
+      [Cl.uint(10000000)],
       address2
     );
     expect(txReceipt.result).toBeOk(Cl.bool(true));
@@ -29,26 +29,16 @@ describe("join-pot", () => {
     txReceipt = simnet.callPublicFn(
       `${address1}.stackpot2`,
       "join-pot",
-      [Cl.uint(20000000), Cl.principal(address2)],
+      [Cl.uint(20000000)],
       address2
     );
     expect(txReceipt.result).toBeErr(Cl.uint(1104)); // already joined
   });
-  it("tx sender required as argument", () => {
-    let txReceipt = simnet.callPublicFn(
-      `${address1}.stackpot2`,
-      "join-pot",
-      [Cl.uint(20000000), Cl.principal(address1)],
-      address2
-    );
-    expect(txReceipt.result).toBeErr(Cl.uint(1105)); // wrong user
-  });
-
   it("user can't join with less than minimum", () => {
     let txReceipt = simnet.callPublicFn(
       `${address1}.stackpot2`,
       "join-pot",
-      [Cl.uint(1), Cl.principal(address2)],
+      [Cl.uint(1)],
       address2
     );
     expect(txReceipt.result).toBeErr(Cl.uint(1302)); // below minimum
@@ -58,7 +48,7 @@ describe("join-pot", () => {
     let txReceipt = simnet.callPublicFn(
       `${address1}.stackpot2`,
       "join-pot",
-      [Cl.uint(10000000), Cl.principal(address1)],
+      [Cl.uint(10000000)],
       address1
     );
     expect(txReceipt.result).toBeErr(Cl.uint(1101)); // unauthorized participant (owner)
@@ -70,22 +60,10 @@ describe("join-pot", () => {
     let txReceipt = simnet.callPublicFn(
       `${address1}.stackpot2`,
       "join-pot",
-      [Cl.uint(10000000), Cl.principal(platformAddress)],
+      [Cl.uint(10000000)],
       platformAddress
     );
     expect(txReceipt.result).toBeErr(Cl.uint(1101)); // unauthorized participant (platform)
-  });
-
-  it("pot treasury address cannot join pot", () => {
-    // pot treasury address is contract address
-    const potTreasuryAddress = `${address1}.stackpot2`;
-    let txReceipt = simnet.callPublicFn(
-      `${address1}.stackpot2`,
-      "join-pot",
-      [Cl.uint(10000000), Cl.principal(potTreasuryAddress)],
-      address2
-    );
-    expect(txReceipt.result).toBeErr(Cl.uint(1105)); // unauthorized participant (treasury)
   });
 
   it("cannot join pot when locked", () => {
@@ -94,7 +72,7 @@ describe("join-pot", () => {
     let txReceipt = simnet.callPublicFn(
       `${address1}.stackpot2`,
       "join-pot",
-      [Cl.uint(10000000), Cl.principal(address2)],
+      [Cl.uint(10000000)],
       address2
     );
     // expect(txReceipt.result).toBeErr(Cl.uint(103)); // delegate locked
@@ -106,7 +84,7 @@ describe("join-pot", () => {
     let txReceipt = simnet.callPublicFn(
       `${address1}.stackpot2`,
       "join-pot",
-      [Cl.uint(100000), Cl.principal(address2)],
+      [Cl.uint(100000)],
       address2
     );
     expect(txReceipt.result).toBeErr(Cl.uint(1408)); // insufficient balance


### PR DESCRIPTION
This PR
* adds function `cancel-pot`

When, for some reason, users missed starting the pot before the deadline, the funds would be stuck forever in the contract. `cancel-pot` allows cancelling the pot after 1 cycle + reward phase length (= 2200 blocks on mainnet)